### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,28 +6,28 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ServoMove KEYWORD1
-ServoEaser KEYWORD1
+ServoMove	KEYWORD1
+ServoEaser	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-reset KEYWORD2
-setMinMaxMicroseconds KEYWORD2
-play KEYWORD2
-getNextPos KEYWORD2
-easeTo KEYWORD2
-update KEYWORD2
-start KEYWORD2
-stop KEYWORD2
-setEasingFunc KEYWORD2
-setArrivedFunc KEYWORD2
-hasArrived KEYWORD2
-isRunning KEYWORD2
-useMicroseconds KEYWORD2
-usingMicroseconds KEYWORD2
+begin	KEYWORD2
+reset	KEYWORD2
+setMinMaxMicroseconds	KEYWORD2
+play	KEYWORD2
+getNextPos	KEYWORD2
+easeTo	KEYWORD2
+update	KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+setEasingFunc	KEYWORD2
+setArrivedFunc	KEYWORD2
+hasArrived	KEYWORD2
+isRunning	KEYWORD2
+useMicroseconds	KEYWORD2
+usingMicroseconds	KEYWORD2
 
 #
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords