### PR TITLE
Call by reference of Servo object in function begin

### DIFF
--- a/ServoEaser.cpp
+++ b/ServoEaser.cpp
@@ -53,7 +53,7 @@ inline float ServoEaser_easeInOutCubic(float t, float b, float c, float d)
 }
 
 // set up an easer with a servo and a moves list
-void ServoEaser::begin(Servo s, int frameTime, 
+void ServoEaser::begin(Servo& s, int frameTime, 
                        ServoMove* mlist, int mcount)
 {
     begin( s, frameTime ); //, servo.read() );
@@ -61,9 +61,9 @@ void ServoEaser::begin(Servo s, int frameTime,
 }
 
 // set up an easer with just a servo and a starting position
-void ServoEaser::begin(Servo s, int frameTime)
+void ServoEaser::begin(Servo& s, int frameTime)
 {
-    servo = s;
+    servo = &s;
     frameMillis = frameTime;
 
     flipped = false;
@@ -83,7 +83,10 @@ void ServoEaser::begin(Servo s, int frameTime)
 // reset easer to initial conditions, does not nuke easingFunc or arrivedFunc
 void ServoEaser::reset()
 {
-    currPos = servo.read();
+    if (servo)
+    {
+        currPos = servo->read();
+    }
     startPos = currPos;  // get everyone in sync
     changePos = 0;       // might be overwritten below
 
@@ -185,10 +188,12 @@ void ServoEaser::update()
         getNextPos(); 
     }
     float p = (flipped) ? 180.0 - currPos : currPos;
-    if( useMicros ) {
-        servo.writeMicroseconds( angleToMicros(p) );
-    } else {
-        servo.write( p );
+    if ( servo )  {
+        if( useMicros ) {
+            servo->writeMicroseconds( angleToMicros(p) );
+        } else {
+            servo->write( p );
+        }
     }
 }
 

--- a/ServoEaser.h
+++ b/ServoEaser.h
@@ -57,7 +57,7 @@ typedef void (*ArrivedFunc)(int currPos, int movesIndex);
 class ServoEaser 
 {
 private:
-    Servo servo;      // what servo we're operating on
+    Servo *servo;      // what servo we're operating on
     int frameMillis;  // minimum update time between servo moves
     float startPos;   // where servo started its tween
     float currPos;    // current servo position, best of our knowledge
@@ -93,8 +93,8 @@ public:
     
     // set up a servoeaser to use a particular servo
     //void begin(Servo s, int frameTime, int startPos);
-    void begin(Servo s, int frameTime); //, int startPos);
-    void begin(Servo s, int frameTime, ServoMove* moves, int movesCount);
+    void begin(Servo& s, int frameTime); //, int startPos);
+    void begin(Servo& s, int frameTime, ServoMove* moves, int movesCount);
 
     void reset();
     


### PR DESCRIPTION
Problem
---------
The function begin of the ServoEaser class has been defined as 

```
    void begin(Servo s, int frameTime); //, int startPos);
    void begin(Servo s, int frameTime, ServoMove* moves, int movesCount);
```
This will create a copy of the Servo object instead of storing a reference to the servo object. This way, 2 Servo objects refer to the same pin. This causes unpredictable behaviour, which is also dependent on the platform used.

Solution
---------
When calling the function begin, you now use the 'call by reference' mechanism on the Servo class. The library then stores a pointer to this Servo class. This way, the API of the library remains backwards compatible.

```
    void begin(Servo& s, int frameTime); //, int startPos);
    void begin(Servo& s, int frameTime, ServoMove* moves, int movesCount);
```